### PR TITLE
fix: refactored SetupServiceAgentUserTest to use constants for maintainability

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,9 @@
     "**/node_modules": true,
     "**/bower_components": true,
     "**/.sfdx": true
+  },
+  "codescan.connectedMode.project": {
+    "connectionId": "prashanth",
+    "projectKey": "Presh-AR-coral-cloud"
   }
 }

--- a/cc-service-app/main/setup/classes/SetupServiceAgentUserTest.cls
+++ b/cc-service-app/main/setup/classes/SetupServiceAgentUserTest.cls
@@ -2,6 +2,8 @@
 private class SetupServiceAgentUserTest {
     private final static String USERNAME = 'agent-user@mock.com';
     private final static String NICKNAME = 'ccagent-mock';
+    private final static String EXISTING_ALIAS = 'existing';
+    private final static String LOCALE = 'en_US';
 
     @IsTest
     static void testSetup_NewUser() {
@@ -63,13 +65,13 @@ private class SetupServiceAgentUserTest {
         User existingUser = new User(
             LastName = 'Existing User',
             Email = USERNAME,
-            Alias = 'existing',
+            Alias = EXISTING_ALIAS,
             Username = USERNAME,
-            CommunityNickname = 'existing',
-            LocaleSidKey = 'en_US',
+            CommunityNickname = EXISTING_ALIAS,
+            LocaleSidKey = LOCALE,
             TimeZoneSidKey = 'GMT',
             ProfileID = p.Id,
-            LanguageLocaleKey = 'en_US',
+            LanguageLocaleKey = LOCALE,
             EmailEncodingKey = 'UTF-8'
         );
         insert existingUser;
@@ -105,13 +107,13 @@ private class SetupServiceAgentUserTest {
         User testUser = new User(
             LastName = 'Existing User',
             Email = USERNAME,
-            Alias = 'existing',
+            Alias = EXISTING_ALIAS,
             Username = USERNAME,
-            CommunityNickname = 'existing',
-            LocaleSidKey = 'en_US',
+            CommunityNickname = EXISTING_ALIAS,
+            LocaleSidKey = LOCALE,
             TimeZoneSidKey = 'GMT',
             ProfileID = p.Id,
-            LanguageLocaleKey = 'en_US',
+            LanguageLocaleKey = LOCALE,
             EmailEncodingKey = 'UTF-8'
         );
         insert testUser;


### PR DESCRIPTION
This pull request refactors the `SetupServiceAgentUserTest` class to use constants for repeated values like `EXISTING_ALIAS` and `LOCALE`. This improves code maintainability and readability by centralizing these values.